### PR TITLE
Fixed core-js missing dependency when using npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ public
 .intermediate-representation/
 .cache/
 yarn.lock
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "babel-plugin-styled-components": "^1.8.0",
+    "core-js": "^2.5.7",
     "disqus-react": "^1.0.5",
     "gatsby": "^2.0.55",
     "gatsby-plugin-feed": "2.0.9",


### PR DESCRIPTION
Implements this fix: https://github.com/gatsbyjs/gatsby/issues/7862

Initially, I had just run: 
```
gatsby new test-blog https://github.com/maxpou/gatsby-starter-morning-dew
```

But would run into this problem:
```
error UNHANDLED REJECTION


  Error: Cannot find module 'core-js/modules/es6.regexp.to-string'
  
  - loader.js:581 Function.Module._resolveFilename
    internal/modules/cjs/loader.js:581:15
  
  - loader.js:507 Function.Module._load
    internal/modules/cjs/loader.js:507:25
  
  - loader.js:637 Module.require
    internal/modules/cjs/loader.js:637:17
  
  - helpers.js:20 require
    internal/modules/cjs/helpers.js:20:18
  
  - render-page.js:3 webpackUniversalModuleDefinition
    /Users/jason/Documents/test-blog/public/render-page.js:3:196
  
  - render-page.js:10 Object.<anonymous>
    /Users/jason/Documents/test-blog/public/render-page.js:10:3
  
  - loader.js:689 Module._compile
    internal/modules/cjs/loader.js:689:30
  
  - loader.js:700 Object.Module._extensions..js
    internal/modules/cjs/loader.js:700:10
  
  - loader.js:599 Module.load
    internal/modules/cjs/loader.js:599:32
  
  - loader.js:538 tryModuleLoad
    internal/modules/cjs/loader.js:538:12
  
  - loader.js:530 Function.Module._load
    internal/modules/cjs/loader.js:530:3
  
  - loader.js:637 Module.require
    internal/modules/cjs/loader.js:637:17
  
  - helpers.js:20 require
    internal/modules/cjs/helpers.js:20:18
  
  - worker.js:32 Promise
    [test-blog]/[gatsby]/dist/utils/worker.js:32:35
  
  - debuggability.js:313 Promise._execute
    [test-blog]/[bluebird]/js/release/debuggability.js:313:9
  
  - promise.js:483 Promise._resolveFromExecutor
    [test-blog]/[bluebird]/js/release/promise.js:483:18
```

This PR fixes the issue.
