### PR TITLE
fix: spelling improvement for footerLinks data

### DIFF
--- a/data/siteConfig.js
+++ b/data/siteConfig.js
@@ -66,7 +66,7 @@ module.exports = {
       sectionName: 'Follow the author',
       links: [
         {
-          label: 'Github',
+          label: 'GitHub',
           url: 'https://github.com/maxpou/gatsby-starter-morning-dew',
         },
         {


### PR DESCRIPTION
- Spelling improvement for the brand names
  - `Github` --> `GitHub`