### PR TITLE
Display captions under images

### DIFF
--- a/content/posts/2018-09-29-a-post-with-images/index.md
+++ b/content/posts/2018-09-29-a-post-with-images/index.md
@@ -16,3 +16,5 @@ tags:
 
 ![a funny gif](./git-push-force.gif)
 
+![a funny gif](./cover.jpg "gatsby-config.js is set to only display a caption if a title is explicitly provided, rather than default to the alt-text. But if a title is provided, it will be centered under the image.")
+

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -51,6 +51,7 @@ module.exports = {
               maxWidth: 590,
               linkImagesToOriginal: false,
               withWebp: true,
+              showCaptions: ['title'],
             },
           },
           { resolve: 'gatsby-remark-prismjs' },

--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -74,6 +74,10 @@ const ContentBody = styled.div`
     font-style: italic;
   }
 
+  & .gatsby-resp-image-figcaption {
+    text-align: center;
+  }
+
   & .gatsby-highlight {
     border-radius: 5px;
     font-size: 15px;


### PR DESCRIPTION
This sets up images to display a caption centered under the image if --- and only if --- a title is explicitly provided. If the user just goes along including images without specifying titles, then this doesn't change the default behavior (that is, it doesn't display the alt-text as a caption or any such thing).