### PR TITLE
Add nested blockquote example

### DIFF
--- a/content/posts/2018-01-03-Big-Sample-Post/index.md
+++ b/content/posts/2018-01-03-Big-Sample-Post/index.md
@@ -316,6 +316,16 @@ Quote break.
 
 Adding multiple > will create nested blockquotes:
 
+```no-highlight
+> blockquote
+>
+> > nested blockquote
+>
+> > **I'm bold!**
+>
+> more quotes
+```
+
 > blockquote
 >
 > > nested blockquote

--- a/content/posts/2018-01-03-Big-Sample-Post/index.md
+++ b/content/posts/2018-01-03-Big-Sample-Post/index.md
@@ -314,6 +314,16 @@ Quote break.
 
 > This is a very long line that will still be quoted properly when it wraps. Oh boy let's keep writing to make sure this is long enough to actually wrap for everyone. Oh, you can put **Markdown** into a blockquote.
 
+Adding multiple > will create nested blockquotes:
+
+> blockquote
+>
+> > nested blockquote
+>
+> > **I'm bold!**
+>
+> more quotes
+
 <a name="html"/>
 
 ## Inline HTML


### PR DESCRIPTION
The example is taken from https://www.gatsbyjs.org/docs/mdx/markdown-syntax/ .

You can see how the nested blockquotes look (as rendered by GitHub) at https://github.com/dHannasch/gatsby-starter-morning-dew/blob/nested-blockquote/content/posts/2018-01-03-Big-Sample-Post/index.md#blockquotes .